### PR TITLE
fix: tighten time validation

### DIFF
--- a/core/utils/__tests__/validators.test.ts
+++ b/core/utils/__tests__/validators.test.ts
@@ -1,0 +1,14 @@
+import { time } from '../validators';
+
+describe('time validator', () => {
+  it('should invalidate minutes over 59', () => {
+    expect(time('10:60', 'hh:mm')).toBe(false);
+    expect(time('10:59', 'hh:mm')).toBe(true);
+  });
+
+  it('should validate 12-hour format correctly', () => {
+    expect(time('00:10 AM', 'hh:mm AM')).toBe(false);
+    expect(time('13:10 AM', 'hh:mm AM')).toBe(false);
+    expect(time('11:10 AM', 'hh:mm AM')).toBe(true);
+  });
+});

--- a/core/utils/validators.ts
+++ b/core/utils/validators.ts
@@ -74,9 +74,10 @@ export const date = (val: string, format: string): boolean => {
 
 export const time = (val: string, format: string): boolean => {
   const { hours, minutes } = getTimeObjFromStr(format, val);
-  const hoursCond = isFormat12hour(format) ? hours <= 12 : hours < 24;
+  const hoursCond = isFormat12hour(format) ? hours >= 1 && hours <= 12 : hours >= 0 && hours < 24;
+  const minutesCond = minutes >= 0 && minutes < 60;
 
-  return hoursCond && minutes <= 60;
+  return hoursCond && minutesCond;
 };
 
 export const isNaturalNumber = (val: number | string): boolean => {


### PR DESCRIPTION
## Summary
- correctly validate time strings so minutes stay below 60 and hours respect 12/24 hour limits
- add tests covering time validator edge cases

## Testing
- `npm test`
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_689e17e88dbc832bb301f3fef28753b1