### PR TITLE
docs: clarify Input readOnly behavior

### DIFF
--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -68,7 +68,7 @@ export interface InputProps extends BaseProps, BaseHtmlProps<HTMLInputElement> {
    */
   autoComplete?: AutoComplete;
   /**
-   * Disables the `Input`, making it unable to type
+   * Prevents editing while keeping the input focusable.
    */
   readOnly?: boolean;
   /**


### PR DESCRIPTION
## Summary
- clarify Input readOnly docs

## Testing
- `node -e "const {withCustomConfig}=require('react-docgen-typescript');const parser=withCustomConfig('./tsconfig.json',{});console.log(JSON.stringify(parser.parse('core/components/atoms/input/Input.tsx'),null,2));" > /tmp/doc.json && jq '.[0].props.readOnly' /tmp/doc.json`
- `npm test core/components/atoms/input`
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_689e43f851a0832b85cfacbc47f729ae