### PR TITLE
fix(collapsible): use numeric expandedWidth default

### DIFF
--- a/core/components/atoms/collapsible/Collapsible.tsx
+++ b/core/components/atoms/collapsible/Collapsible.tsx
@@ -131,7 +131,7 @@ Collapsible.defaultProps = {
   expanded: false,
   hoverable: true,
   height: '100%',
-  expandedWidth: '240px',
+  expandedWidth: 240,
   withTrigger: true,
 };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1388,9 +1388,9 @@ export declare const Collapsible: {
 	defaultProps: {
 		expanded: boolean;
 		hoverable: boolean;
-		height: string;
-		expandedWidth: string;
-	};
+                height: string;
+                expandedWidth: number;
+        };
 };
 export declare type StatusType = "failed" | "sending" | "sent" | "read" | "urgent";
 export interface StatusProps extends BaseProps {


### PR DESCRIPTION
## Summary
- switch Collapsible's `expandedWidth` default from string `'240px'` to numeric `240`
- align type declarations with numeric `expandedWidth` default

## Testing
- `npm test -- core/components/atoms/collapsible/__tests__/Collapsible.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e43e9b394832ba75cbadd6000002a