### PR TITLE
docs: fix warning heading typo

### DIFF
--- a/css/Readme.md
+++ b/css/Readme.md
@@ -29,7 +29,7 @@
 | --success-lighter 	| `#A5D8AA` 	| ![#A5D8AA](https://via.placeholder.com/15/A5D8AA/000000?text=+) 	|
 | --success-lightest 	| `#D7EFDF` 	| ![#D7EFDF](https://via.placeholder.com/15/D7EFDF/000000?text=+) 	|
 
-## WARNNING
+## WARNING
 | Token 	| value 	| preview 	|
 |-	|-	|-	|
 | --warning 	| `#FFC208` 	| ![#FFC208](https://via.placeholder.com/15/FFC208/000000?text=+) 	|


### PR DESCRIPTION
## Summary
- fix typo in CSS README's WARNING section heading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e43e066ec832b98b1440e175b91ec