### PR TITLE
fix: consider popover in outside click

### DIFF
--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -351,11 +351,15 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
       let clickInsideLayer = false;
       let shouldClose = false;
 
-      const openedLayers = container.querySelectorAll('[data-opened="true"]');
+      const openedLayers = Array.from(container.querySelectorAll('[data-opened="true"]')) as Element[];
+      if (popover) {
+        openedLayers.push(popover);
+      }
+
       openedLayers.forEach((layer) => {
-        if (layer && layer.contains(clicked)) {
+        if (layer && (layer as HTMLElement).contains(clicked)) {
           clickInsideLayer = true;
-          const clickedIndex = parseInt(window.getComputedStyle(layer).zIndex);
+          const clickedIndex = parseInt(window.getComputedStyle(layer as HTMLElement).zIndex);
           if (popoverIndex > clickedIndex) {
             shouldClose = true;
             return;
@@ -370,7 +374,12 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     };
 
     const onOutsideClickHandler = (event: Event) => {
-      const { open, closeOnBackdropClick } = this.props;
+      const { open, closeOnBackdropClick, on } = this.props;
+
+      if (on === 'hover' && this.doesEventContainsElement(event, this.popupRef)) {
+        return;
+      }
+
       if (open && shouldPopoverClose(event.target as HTMLElement) && closeOnBackdropClick) {
         if (!this.doesEventContainsElement(event, this.popupRef)) {
           this.togglePopper('outsideClick');

--- a/core/components/molecules/popover/__tests__/Popover.test.tsx
+++ b/core/components/molecules/popover/__tests__/Popover.test.tsx
@@ -162,6 +162,25 @@ describe('renders Popover component with prop: closeOnBackdropClick', () => {
   });
 });
 
+describe('Popover stays open on hover when clicked inside', () => {
+  it('does not close popover when clicked inside after hover', () => {
+    const { getByTestId } = render(
+      <Popover trigger={trigger} on="hover" appendToBody={false}>
+        <div data-test="DesignSystem-Popover--Inner">Content</div>
+      </Popover>
+    );
+
+    const popoverTrigger = getByTestId('DesignSystem-PopoverTrigger');
+    fireEvent.mouseEnter(popoverTrigger);
+
+    const inner = getByTestId('DesignSystem-Popover--Inner');
+    fireEvent.click(inner);
+
+    expect(getByTestId('DesignSystem-Popover')).toBeInTheDocument();
+    cleanup();
+  });
+});
+
 describe('renders Popover component with prop: open and onToggle', () => {
   it('Popover component with open: false', () => {
     const { queryByTestId } = render(


### PR DESCRIPTION
## Summary
- include popover element when determining if a click lies within open layers
- skip closing logic for hover-triggered popovers when clicking inside
- add unit test for hover + click scenario to ensure popover remains open

## Testing
- `npm test core/components/molecules/popover/__tests__/Popover.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e4ec12db8832bbd2bef5b50948384