### PR TITLE
feat(table): expose refresh method

### DIFF
--- a/core/components/organisms/table/Table.tsx
+++ b/core/components/organisms/table/Table.tsx
@@ -655,6 +655,10 @@ export class Table extends React.Component<TableProps, TableState> {
     }
   };
 
+  public refresh = () => {
+    this.updateData();
+  };
+
   fetchDataOnScroll = async (props: { page: number; rowsCount: number }) => {
     const { sortingList, filterList, searchTerm } = this.state;
 

--- a/core/components/organisms/table/__stories__/asyncTable.story.jsx
+++ b/core/components/organisms/table/__stories__/asyncTable.story.jsx
@@ -7,6 +7,7 @@ import { fetchData } from '@/components/organisms/grid/__stories__/_common_/fetc
 import { action } from '@/utils/action';
 
 export const asyncTable = () => {
+  const tableRef = React.useRef(null);
   const selectionActionRenderer = (selectedData, selectAll) => {
     action('selectedData', selectedData, 'selectAll', selectAll)();
     return (
@@ -21,8 +22,12 @@ export const asyncTable = () => {
 
   return (
     <div>
+      <Button className="mb-4" onClick={() => tableRef.current.refresh()}>
+        Refresh
+      </Button>
       <Card className="h-100 overflow-hidden">
         <Table
+          ref={tableRef}
           loaderSchema={loaderSchema}
           fetchData={fetchData}
           withHeader={true}
@@ -51,6 +56,7 @@ export const asyncTable = () => {
 
 const customCode = `
 () => {
+  const tableRef = React.useRef(null);
   const translateData = (schema, data) => {
     let newData = data;
 
@@ -293,8 +299,12 @@ const customCode = `
 
   return (
     <div>
+      <Button className="mb-4" onClick={() => tableRef.current.refresh()}>
+        Refresh
+      </Button>
       <Card className="h-100 overflow-hidden">
         <Table
+          ref={tableRef}
           loaderSchema={loaderSchema}
           fetchData={fetchData}
           withHeader={true}

--- a/core/components/organisms/table/__tests__/Table.test.tsx
+++ b/core/components/organisms/table/__tests__/Table.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, waitFor, screen, cleanup } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen, cleanup, act } from '@testing-library/react';
 import { Table, Button } from '@/index';
 import { TableProps as Props } from '@/index.type';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
@@ -940,5 +940,28 @@ describe('render table with custom selection/unselection label renderers', () =>
     fireEvent.animationEnd(selectionLabel);
 
     expect(selectionLabel).toHaveTextContent('Custom unselected label');
+  });
+});
+
+describe('Table refresh', () => {
+  it('re-fetches data on refresh', async () => {
+    const fetchDataMock = jest.fn(() =>
+      Promise.resolve({
+        schema: tableSchema,
+        data: tableData,
+        count: tableData.length,
+        searchTerm: '',
+      })
+    );
+    const tableRef = React.createRef<any>();
+    render(<Table ref={tableRef} fetchData={fetchDataMock} />);
+
+    await waitFor(() => expect(fetchDataMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      tableRef.current.refresh();
+    });
+
+    await waitFor(() => expect(fetchDataMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/core/components/organisms/table/index.tsx
+++ b/core/components/organisms/table/index.tsx
@@ -1,2 +1,18 @@
-export { default } from './Table';
-export * from './Table';
+import * as React from 'react';
+import TableComponent, {
+  TableProps,
+  ErrorTemplateProps,
+  FilterPosition,
+  SyncTableProps,
+  AsyncTableProps,
+  defaultProps,
+} from './Table';
+
+export type { TableProps, ErrorTemplateProps, FilterPosition, SyncTableProps, AsyncTableProps };
+export { defaultProps };
+
+const Table = React.forwardRef<TableComponent, TableProps>((props, ref) => <TableComponent {...props} ref={ref} />);
+Table.displayName = 'Table';
+
+export default Table;
+export { Table };


### PR DESCRIPTION
## Summary
- expose `refresh` on Table for async data reloads
- forward Table ref to allow parent components to trigger `refresh`
- document and test refresh behaviour

## Testing
- `npm test core/components/organisms/table/__tests__/Table.test.tsx -t "re-fetches data on refresh" --runInBand --silent | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689e4ed33890832b8c92e7ccbf226120