### PR TITLE
fix: prevent onClick firing for active vertical nav items

### DIFF
--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -114,6 +114,7 @@ export const MenuItem = (props: MenuItemProps) => {
 
   const onClickHandler = (ev: { preventDefault: () => void }) => {
     ev.preventDefault();
+    if (isActive) return;
     if (onClick) onClick(menu);
   };
 

--- a/core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx
+++ b/core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx
@@ -304,6 +304,16 @@ describe('Vertical Navigation component active menu', () => {
 });
 
 describe('Vertical Navigation component prop: onClick', () => {
+  it('does not call onClick callback when active menu item is clicked', () => {
+    const menuClicked = 0;
+    onClick.mockReset();
+    const { getAllByTestId } = render(<VerticalNav menus={menus} active={{ name: 'patient_360' }} onClick={onClick} />);
+
+    const activeMenu = getAllByTestId('DesignSystem-VerticalNav--Item')[menuClicked];
+    fireEvent.click(activeMenu);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it('calls onClick callback', () => {
     const menuClicked = 0;
     const { getAllByTestId } = render(<VerticalNav menus={menus} active={active} onClick={onClick} />);


### PR DESCRIPTION
## Summary
- avoid invoking `onClick` when a vertical nav item is already active
- add regression test ensuring active items don't trigger `onClick`

## Testing
- `npm test -- core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e4ed52cbc832b8f71617b7e559cda