### PR TITLE
feat(chipInput): add keyboard navigation and a11y

### DIFF
--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -18,69 +18,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="0"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="1"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -124,69 +138,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="0"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
             tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--default Text--regular Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="-1"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--default Text--regular Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="-1"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="1"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
             tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--default Text--regular Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="-1"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--default Text--regular Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="-1"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -231,69 +259,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="0"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="1"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input

--- a/docs/src/pages/components/chipInput/interactions.mdx
+++ b/docs/src/pages/components/chipInput/interactions.mdx
@@ -1,0 +1,31 @@
+### Keyboard Interactions
+
+<table style={{width: "100%"}}>
+  <tbody>
+    <tr>
+      <th style={{width:"33%", textAlign: "left"}}>Initial state</th>
+      <th style={{width:"33%", textAlign: "left"}}>Keyboard Interaction</th>
+      <th style={{width:"33%", textAlign: "left"}}>Final state</th>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Input is focused</td>
+      <td>&lt;left arrow&gt;</td>
+      <td>Focus shifts to the last chip.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip is focused</td>
+      <td>&lt;left arrow&gt; / &lt;right arrow&gt;</td>
+      <td>Move focus to the previous or next chip. When focus is on the last chip and the right arrow is pressed, focus moves to the input.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip is focused</td>
+      <td>&lt;Backspace&gt; / &lt;Delete&gt;</td>
+      <td>Remove the focused chip.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Component has chips</td>
+      <td>&lt;Escape&gt;</td>
+      <td>Clear all chips and focus the input.</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- improve ChipInput keyboard accessibility with arrow navigation, chip deletion, and Esc clear
- document keyboard interactions for ChipInput
- add tests for keyboard navigation and deletion

## Testing
- `npm test -- core/components/molecules/chipInput/__tests__/ChipInput.test.tsx -u`
- `npx eslint core/components/molecules/chipInput/ChipInput.tsx core/components/molecules/chipInput/__tests__/ChipInput.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689e4ede3460832ba6f8910a3e53971b