### PR TITLE
feat: improve chip input keyboard a11y

### DIFF
--- a/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
+++ b/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { ChipInput } from '@/index';
 import { ChipInputProps as Props } from '@/index.type';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
@@ -185,6 +185,48 @@ describe('Uncontrolled ChipInput component', () => {
 
     expect(FunctionValue).toHaveBeenCalled();
     expect(queryAllByTestId('DesignSystem-ChipInput--Chip')).toHaveLength(newValue.length);
+  });
+});
+
+describe('ChipInput keyboard accessibility', () => {
+  it('navigates between chips and input using arrow keys', async () => {
+    const { getByTestId, getAllByTestId } = render(<ChipInput defaultValue={value} />);
+
+    const input = getByTestId('DesignSystem-ChipInput--Input');
+    input.focus();
+
+    fireEvent.keyDown(input, { key: 'ArrowLeft' });
+    const wrappers = getAllByTestId('DesignSystem-ChipInput--ChipWrapper');
+    await waitFor(() => expect(wrappers[1]).toHaveFocus());
+
+    fireEvent.keyDown(wrappers[1], { key: 'ArrowLeft' });
+    await waitFor(() => expect(wrappers[0]).toHaveFocus());
+
+    fireEvent.keyDown(wrappers[0], { key: 'ArrowRight' });
+    await waitFor(() => expect(wrappers[1]).toHaveFocus());
+
+    fireEvent.keyDown(wrappers[1], { key: 'ArrowRight' });
+    await waitFor(() => expect(input).toHaveFocus());
+  });
+
+  it('deletes focused chip and clears all chips with escape', async () => {
+    const { getByTestId, getAllByTestId, queryAllByTestId } = render(<ChipInput defaultValue={value} />);
+
+    const input = getByTestId('DesignSystem-ChipInput--Input');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'ArrowLeft' });
+
+    let wrappers = getAllByTestId('DesignSystem-ChipInput--ChipWrapper');
+    await waitFor(() => expect(wrappers[1]).toHaveFocus());
+
+    fireEvent.keyDown(wrappers[1], { key: 'Delete' });
+    await waitFor(() => expect(getAllByTestId('DesignSystem-ChipInput--ChipWrapper')).toHaveLength(1));
+    wrappers = getAllByTestId('DesignSystem-ChipInput--ChipWrapper');
+    await waitFor(() => expect(wrappers[0]).toHaveFocus());
+
+    fireEvent.keyDown(wrappers[0], { key: 'Escape' });
+    await waitFor(() => expect(queryAllByTestId('DesignSystem-ChipInput--ChipWrapper')).toHaveLength(0));
+    expect(input).toHaveFocus();
   });
 });
 

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -18,69 +18,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
-            data-test="DesignSystem-ChipInput--Chip"
+            class="my-3 mx-2"
+            data-test="DesignSystem-ChipInput--ChipWrapper"
             role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-ChipInput--Chip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
-            data-test="DesignSystem-ChipInput--Chip"
+            class="my-3 mx-2"
+            data-test="DesignSystem-ChipInput--ChipWrapper"
             role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-ChipInput--Chip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -88,6 +102,7 @@ exports[`ChipInput component
             data-test="DesignSystem-ChipInput--Input"
             placeholder=""
             style="flex-basis: 0px;"
+            tabindex="0"
             value=""
           />
         </div>
@@ -124,69 +139,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear my-3 mx-2"
-            data-test="DesignSystem-ChipInput--Chip"
+            class="my-3 mx-2"
+            data-test="DesignSystem-ChipInput--ChipWrapper"
             role="button"
-            style="max-width: 256px;"
             tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--default Text--regular Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear"
+              data-test="DesignSystem-ChipInput--Chip"
               role="button"
+              style="max-width: 256px;"
               tabindex="-1"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--default Text--regular Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="-1"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear my-3 mx-2"
-            data-test="DesignSystem-ChipInput--Chip"
+            class="my-3 mx-2"
+            data-test="DesignSystem-ChipInput--ChipWrapper"
             role="button"
-            style="max-width: 256px;"
             tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--default Text--regular Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear"
+              data-test="DesignSystem-ChipInput--Chip"
               role="button"
+              style="max-width: 256px;"
               tabindex="-1"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--default Text--regular Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="-1"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -195,6 +224,7 @@ exports[`ChipInput component
             disabled=""
             placeholder=""
             style="flex-basis: 0px;"
+            tabindex="0"
             value=""
           />
         </div>
@@ -231,69 +261,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
-            data-test="DesignSystem-ChipInput--Chip"
+            class="my-3 mx-2"
+            data-test="DesignSystem-ChipInput--ChipWrapper"
             role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-ChipInput--Chip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
-            data-test="DesignSystem-ChipInput--Chip"
+            class="my-3 mx-2"
+            data-test="DesignSystem-ChipInput--ChipWrapper"
             role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-ChipInput--Chip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -301,6 +345,7 @@ exports[`ChipInput component
             data-test="DesignSystem-ChipInput--Input"
             placeholder=""
             style="flex-basis: 0px;"
+            tabindex="0"
             value=""
           />
         </div>

--- a/docs/src/pages/components/chipInput/interactions.mdx
+++ b/docs/src/pages/components/chipInput/interactions.mdx
@@ -1,0 +1,43 @@
+### Keyboard Interactions
+
+<br />
+
+<table style={{width: "100%"}}>
+  <tbody>
+    <tr>
+      <th style={{width:"33%", textAlign: "left"}}>Initial state</th>
+      <th style={{width:"33%", textAlign: "left"}}>Keyboard Interaction</th>
+      <th style={{width:"33%", textAlign: "left"}}>Final state</th>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Input in focus with chips present</td>
+      <td>&#60;left arrow&#62;</td>
+      <td>Focus shifts to the last chip.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip in focus</td>
+      <td>&#60;left arrow&#62;</td>
+      <td>Focus shifts to the previous chip.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip in focus</td>
+      <td>&#60;right arrow&#62;</td>
+      <td>
+        <ul>
+          <li>Focus shifts to the next chip.</li>
+          <li>If on the last chip, focus moves to the input.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip in focus</td>
+      <td>&#60;Backspace/Delete&#62;</td>
+      <td>Remove the focused chip and focus the previous chip or the input if no chips remain.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Input or chip in focus</td>
+      <td>&#60;Escape&#62;</td>
+      <td>Clear all chips and focus the input.</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- support chip focus management and keyboard navigation in ChipInput
- document ChipInput keyboard interactions
- add tests for navigating and deleting chips

## Testing
- `npm test -- core/components/molecules/chipInput/__tests__/ChipInput.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689e5a2e731c832b84b302060e447b64